### PR TITLE
Update NuGetAuthenticate service connection to basic auth

### DIFF
--- a/azure-pipelines/templates/build-steps-template.yml
+++ b/azure-pipelines/templates/build-steps-template.yml
@@ -59,7 +59,7 @@ steps:
   - task: NuGetAuthenticate@1
     displayName: 'Authenticate to IG ProGet NuGet feed'
     inputs:
-      nuGetServiceConnections: 'IG ProGet NuGet'
+      nuGetServiceConnections: 'IG ProGet IgniteUINuGet - Staging'
       forceReinstallCredentialProvider: true
 
   - task: DotNetCoreCLI@2


### PR DESCRIPTION
We're seeing an error while authenticating against a service connection that uses an API key. according to the documentation for this task, this does not appear to be supported. Trying to switch it to use a connection with basic authentication.