### PR TITLE
Update package source name to "IG ProGet IgniteUINuGet - Staging"

### DIFF
--- a/azure-pipelines/templates/build-steps-template.yml
+++ b/azure-pipelines/templates/build-steps-template.yml
@@ -41,7 +41,7 @@ steps:
       targetType: 'inline'
       script: |
         dotnet new nugetconfig --force
-        dotnet nuget add source ${{ parameters.igNuGetFeedUrl }} --name "IG ProGet NuGet" 
+        dotnet nuget add source ${{ parameters.igNuGetFeedUrl }} --name "IG ProGet IgniteUINuGet - Staging" 
 
         $xml = [XML](Get-Content '.\IgBlazorSamples.${{ parameters.projectToBuild }}.csproj');
 
@@ -57,7 +57,7 @@ steps:
       workingDirectory: '$(Build.SourcesDirectory)\browser\IgBlazorSamples.${{ parameters.projectToBuild }}'
 
   - task: NuGetAuthenticate@1
-    displayName: 'Authenticate to IG ProGet NuGet feed'
+    displayName: 'Authenticate to IG ProGet IgniteUINuGet - Staging feed'
     inputs:
       nuGetServiceConnections: 'IG ProGet IgniteUINuGet - Staging'
       forceReinstallCredentialProvider: true


### PR DESCRIPTION
Seeing an error authenticating to the staging feed. While it worked recently, it may be an issue with a naming mismatch between the package source created in the nuget.config file we generate and the name for the service connection used for credentials that didn't appear until after a system reboot.