### PR TITLE
Update samples to use recommended way of getting grid columns.

### DIFF
--- a/samples/grids/grid/finjs/App.razor
+++ b/samples/grids/grid/finjs/App.razor
@@ -491,7 +491,7 @@
     public void OnCellClick(IgbGridCellEventArgs e)
     {
         int colIndex = e.Detail.Cell.Id.ColumnID;
-        IgbColumn column = grid1.ActualColumnList.ElementAt(colIndex);
+        IgbColumn column = grid1.GetColumns().ElementAt(colIndex);
         if (column.Field == "Chart")
         {
             string key = e.Detail.Cell.Id.RowID;


### PR DESCRIPTION
In general we shouldn't use the `ContentColumnsList` or `ActualColumnsList` collections publicly for blazor and instead should use the provided GetColumns() method.