### PR TITLE
Fix stepper animations sample

### DIFF
--- a/samples/layouts/stepper/animations/App.razor
+++ b/samples/layouts/stepper/animations/App.razor
@@ -89,7 +89,7 @@
         this.stepper.HorizontalAnimation = animation;
     }
 
-    public void AnimationDurationChange(IgbComponentDataValueChangedEventArgs args)
+    public void AnimationDurationChange(IgbComponentValueChangedEventArgs args)
     {
         double duration;
         double.TryParse(args.Detail.ToString(), out duration);


### PR DESCRIPTION
Stepper animations sample currently breaks as it tries to pass an object of class `IgbComponentDataValueChangedEventArgs` to the change event which expects an object of class `IgbComponentValueChangedEventArgs`