### PR TITLE
switch from using InvokeUnmarshalled to JSImport for downloading exce…

### DIFF
--- a/browser/IgBlazorSamples.Client/IgBlazorSamples.Client.csproj
+++ b/browser/IgBlazorSamples.Client/IgBlazorSamples.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
-
+ 
     <!-- note copied Nullable/ImplicitUsings from a new Blazor project that targets .NET 6 -->
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -12,6 +12,8 @@
     <RootNamespace>Infragistics.Samples</RootNamespace>
     <Version>4.0.0</Version>
     <BlazorCacheBootResources>false</BlazorCacheBootResources>
+    <!-- this is required for excel WASM samples for fast file download -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -54,6 +56,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.JSInterop.WebAssembly" Version="9.0.0" />
     <PackageReference Include="System.Net.Http.Json" Version="9.0.0" />
   </ItemGroup>
 

--- a/browser/IgBlazorSamples.Client/wwwroot/BlazorFastDownloadFile.js
+++ b/browser/IgBlazorSamples.Client/wwwroot/BlazorFastDownloadFile.js
@@ -1,0 +1,19 @@
+﻿// these methods are from:  
+// https://www.meziantou.net/generating-and-downloading-a-file-in-a-blazor-webassembly-application.htm
+export function BlazorDownloadFileFast(name, contentType, content) {
+    var nameStr = name;
+    var contentTypeStr = contentType;
+    var contentArray = new Uint8Array(content);
+    // Create the URL
+    var file = new File([contentArray], nameStr, { type: contentTypeStr });
+    var exportUrl = URL.createObjectURL(file);
+    // Create the <a> element and click on it
+    var a = document.createElement("a");
+    document.body.appendChild(a);
+    a.href = exportUrl;
+    a.download = nameStr;
+    a.target = "_self";
+    a.click();
+    // We don't need to keep the url, let's release the memory
+    URL.revokeObjectURL(exportUrl);
+}

--- a/browser/IgBlazorSamples.Gulp/tasks/gulp-samples.js
+++ b/browser/IgBlazorSamples.Gulp/tasks/gulp-samples.js
@@ -213,6 +213,8 @@ function getSamples(cb) {
                     sampleFolder + "/**/*.cs",
                     sampleFolder + "/*.csproj",
                     sampleFolder + "/wwwroot/*.js",
+					// this file has been added to SB since it needs to be in a particular location (directly under wwwroot) for import to work
+					'!' + sampleFolder + "/wwwroot/BlazorFastDownloadFile.js",
                     sampleFolder + "/wwwroot/*.css",
                     sampleFolder + "/wwwroot/index.html",
                  // sampleFolder + "/wwwroot/*",
@@ -226,7 +228,8 @@ function getSamples(cb) {
               '!' + sampleFolder + "/obj/**",
               '!' + sampleFolder + "/obj/*.*",
               '!' + sampleFolder + "/bin/**",
-              '!' + sampleFolder + "/bin/*.*",])
+              '!' + sampleFolder + "/bin/*.*",
+			  ])
             .pipe(flatten({ "includeParents": -1 }))
             .pipe(es.map(function(file, fileCallback) {
                 let fileDir = Transformer.getRelative(file.dirname);

--- a/samples/excel/excel-library/operations-on-workbooks/App.razor
+++ b/samples/excel/excel-library/operations-on-workbooks/App.razor
@@ -12,7 +12,9 @@
 @using Microsoft.JSInterop.WebAssembly
 @using Infragistics.Documents.Excel
 @using IgniteUI.Blazor.Controls
+@using System.Runtime.InteropServices.JavaScript
 
+@implements IDisposable
 
 <div class="container vertical">
 
@@ -33,8 +35,8 @@
         @if (Data != null)
         {
             <IgbDataGrid @ref="@grid" Height="100%" Width="100%"
-                      DataSource="Data"
-                      AutoGenerateColumns="true">
+            DataSource="Data"
+            AutoGenerateColumns="true">
             </IgbDataGrid>
         }
 
@@ -310,13 +312,32 @@
 
     }
 
-    public void SaveFile(byte[] bytes, string fileName, string mime)
+    JSObject module;    
+    bool moduleDownloaded = false;
+    public async void SaveFile(byte[] bytes, string fileName, string mime)
     {
         if (Runtime is WebAssemblyJSRuntime wasmRuntime)
-            wasmRuntime.InvokeUnmarshalled<string, string, byte[], bool>("BlazorDownloadFileFast", fileName, mime, bytes);
+        {
+            if (!moduleDownloaded)
+            {
+                module = await JSHost.ImportAsync("BlazorFastDownload", "../BlazorFastDownloadFile.js");
+                moduleDownloaded = true;
+            }
+            BlazorFastDownload.DownloadFile(fileName, mime, bytes);
+        }
         else if (Runtime is IJSInProcessRuntime inProc)
             inProc.InvokeVoid("BlazorDownloadFile", fileName, mime, bytes);
+
+        
     }
+    public void Dispose()
+    {
+        if (moduleDownloaded && module != null)
+        {
+            module.Dispose();
+        }
+    }
+   
 
     public void OnTableChange(ChangeEventArgs args)
     {

--- a/samples/excel/excel-library/operations-on-workbooks/BlazorClientApp.csproj
+++ b/samples/excel/excel-library/operations-on-workbooks/BlazorClientApp.csproj
@@ -5,6 +5,8 @@
     <RazorLangVersion>3.0</RazorLangVersion>
     <AssemblyName>Infragistics.Samples</AssemblyName>
     <RootNamespace>Infragistics.Samples</RootNamespace>
+	<!-- this is required for excel WASM samples for fast file download -->
+	 <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -18,6 +20,8 @@
       <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
 
       <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0" />
+
+      <PackageReference Include="Microsoft.JSInterop.WebAssembly" Version="9.0.0" />
       <PackageReference Include="System.Net.Http.Json" Version="9.0.0" />
   </ItemGroup>
 

--- a/samples/excel/excel-library/operations-on-workbooks/BlazorFastDownload.cs
+++ b/samples/excel/excel-library/operations-on-workbooks/BlazorFastDownload.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.InteropServices.JavaScript;
+
+namespace Infragistics.Samples
+{
+    public partial class BlazorFastDownload
+    {
+        [JSImport("BlazorDownloadFileFast", "BlazorFastDownload")]
+        internal static partial void DownloadFile(string name, string contentType, byte[] content);
+
+    }
+}

--- a/samples/excel/excel-library/operations-on-workbooks/wwwroot/BlazorDownloadFile.js
+++ b/samples/excel/excel-library/operations-on-workbooks/wwwroot/BlazorDownloadFile.js
@@ -1,23 +1,6 @@
 ﻿// these methods are from:
 // https://www.meziantou.net/generating-and-downloading-a-file-in-a-blazor-webassembly-application.htm
-function BlazorDownloadFileFast(name, contentType, content) {
-    // Convert the parameters to actual JS types
-    var nameStr = BINDING.conv_string(name);
-    var contentTypeStr = BINDING.conv_string(contentType);
-    var contentArray = Blazor.platform.toUint8Array(content);
-    // Create the URL
-    var file = new File([contentArray], nameStr, { type: contentTypeStr });
-    var exportUrl = URL.createObjectURL(file);
-    // Create the <a> element and click on it
-    var a = document.createElement("a");
-    document.body.appendChild(a);
-    a.href = exportUrl;
-    a.download = nameStr;
-    a.target = "_self";
-    a.click();
-    // We don't need to keep the url, let's release the memory
-    URL.revokeObjectURL(exportUrl);
-}
+
 function BlazorDownloadFile(filename, contentType, content) {
     // Blazor marshall byte[] to a base64 string, so we first need to convert the string (content) to a Uint8Array to create the File
     var data = base64DecToArr(content);

--- a/samples/excel/excel-library/operations-on-workbooks/wwwroot/BlazorFastDownloadFile.js
+++ b/samples/excel/excel-library/operations-on-workbooks/wwwroot/BlazorFastDownloadFile.js
@@ -1,0 +1,20 @@
+﻿// these methods are from:
+// https://www.meziantou.net/generating-and-downloading-a-file-in-a-blazor-webassembly-application.htm
+export function BlazorDownloadFileFast(name, contentType, content) {
+    // Convert the parameters to actual JS types
+    var nameStr = name;
+    var contentTypeStr = contentType;
+    var contentArray = new Uint8Array(content);
+    // Create the URL
+    var file = new File([contentArray], nameStr, { type: contentTypeStr });
+    var exportUrl = URL.createObjectURL(file);
+    // Create the <a> element and click on it
+    var a = document.createElement("a");
+    document.body.appendChild(a);
+    a.href = exportUrl;
+    a.download = nameStr;
+    a.target = "_self";
+    a.click();
+    // We don't need to keep the url, let's release the memory
+    URL.revokeObjectURL(exportUrl);
+}

--- a/samples/excel/excel-library/operations-on-worksheets/App.razor
+++ b/samples/excel/excel-library/operations-on-worksheets/App.razor
@@ -14,6 +14,9 @@
 @using Documents.Excel.ConditionalFormatting
 @using Documents.Excel.Sorting
 @using Documents.Excel.Filtering
+@using System.Runtime.InteropServices.JavaScript
+
+@implements IDisposable
 
 <div class="container vertical">
 
@@ -233,12 +236,30 @@
 
     }
 
-    public void SaveFile(byte[] bytes, string fileName, string mime)
+    JSObject module;
+    bool moduleDownloaded = false;
+    public async void SaveFile(byte[] bytes, string fileName, string mime)
     {
         if (Runtime is WebAssemblyJSRuntime wasmRuntime)
-            wasmRuntime.InvokeUnmarshalled<string, string, byte[], bool>("BlazorDownloadFileFast", fileName, mime, bytes);
+        {
+            if (!moduleDownloaded)
+            {
+                module = await JSHost.ImportAsync("BlazorFastDownload", "../BlazorFastDownloadFile.js");
+                moduleDownloaded = true;
+            }
+            BlazorFastDownload.DownloadFile(fileName, mime, bytes);
+        }
         else if (Runtime is IJSInProcessRuntime inProc)
             inProc.InvokeVoid("BlazorDownloadFile", fileName, mime, bytes);
+
+
+    }
+    public void Dispose()
+    {
+        if (moduleDownloaded && module != null)
+        {
+            module.Dispose();
+        }
     }
 
     public void OnSortChange(ChangeEventArgs args)

--- a/samples/excel/excel-library/operations-on-worksheets/BlazorClientApp.csproj
+++ b/samples/excel/excel-library/operations-on-worksheets/BlazorClientApp.csproj
@@ -5,6 +5,8 @@
     <RazorLangVersion>3.0</RazorLangVersion>
     <AssemblyName>Infragistics.Samples</AssemblyName>
     <RootNamespace>Infragistics.Samples</RootNamespace>
+	<!-- this is required for excel WASM samples for fast file download -->
+	 <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -18,6 +20,8 @@
       <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
 
       <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0" />
+
+      <PackageReference Include="Microsoft.JSInterop.WebAssembly" Version="9.0.0" />
       <PackageReference Include="System.Net.Http.Json" Version="9.0.0" />
   </ItemGroup>
 

--- a/samples/excel/excel-library/operations-on-worksheets/BlazorFastDownload.cs
+++ b/samples/excel/excel-library/operations-on-worksheets/BlazorFastDownload.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.InteropServices.JavaScript;
+
+namespace Infragistics.Samples
+{
+    public partial class BlazorFastDownload
+    {
+        [JSImport("BlazorDownloadFileFast", "BlazorFastDownload")]
+        internal static partial void DownloadFile(string name, string contentType, byte[] content);
+
+    }
+}

--- a/samples/excel/excel-library/operations-on-worksheets/wwwroot/BlazorDownloadFile.js
+++ b/samples/excel/excel-library/operations-on-worksheets/wwwroot/BlazorDownloadFile.js
@@ -1,23 +1,6 @@
 ﻿// these methods are from:
 // https://www.meziantou.net/generating-and-downloading-a-file-in-a-blazor-webassembly-application.htm
-function BlazorDownloadFileFast(name, contentType, content) {
-    // Convert the parameters to actual JS types
-    var nameStr = BINDING.conv_string(name);
-    var contentTypeStr = BINDING.conv_string(contentType);
-    var contentArray = Blazor.platform.toUint8Array(content);
-    // Create the URL
-    var file = new File([contentArray], nameStr, { type: contentTypeStr });
-    var exportUrl = URL.createObjectURL(file);
-    // Create the <a> element and click on it
-    var a = document.createElement("a");
-    document.body.appendChild(a);
-    a.href = exportUrl;
-    a.download = nameStr;
-    a.target = "_self";
-    a.click();
-    // We don't need to keep the url, let's release the memory
-    URL.revokeObjectURL(exportUrl);
-}
+
 function BlazorDownloadFile(filename, contentType, content) {
     // Blazor marshall byte[] to a base64 string, so we first need to convert the string (content) to a Uint8Array to create the File
     var data = base64DecToArr(content);

--- a/samples/excel/excel-library/operations-on-worksheets/wwwroot/BlazorFastDownloadFile.js
+++ b/samples/excel/excel-library/operations-on-worksheets/wwwroot/BlazorFastDownloadFile.js
@@ -1,0 +1,20 @@
+﻿// these methods are from:
+// https://www.meziantou.net/generating-and-downloading-a-file-in-a-blazor-webassembly-application.htm
+export function BlazorDownloadFileFast(name, contentType, content) {
+    // Convert the parameters to actual JS types
+    var nameStr = name;
+    var contentTypeStr = contentType;
+    var contentArray = new Uint8Array(content);
+    // Create the URL
+    var file = new File([contentArray], nameStr, { type: contentTypeStr });
+    var exportUrl = URL.createObjectURL(file);
+    // Create the <a> element and click on it
+    var a = document.createElement("a");
+    document.body.appendChild(a);
+    a.href = exportUrl;
+    a.download = nameStr;
+    a.target = "_self";
+    a.click();
+    // We don't need to keep the url, let's release the memory
+    URL.revokeObjectURL(exportUrl);
+}

--- a/samples/excel/excel-library/operations-on-worksheets/wwwroot/index.html
+++ b/samples/excel/excel-library/operations-on-worksheets/wwwroot/index.html
@@ -26,6 +26,7 @@
     <!-- importing blazor scripts for IG Excel: -->
     <script src="_content/IgniteUI.Blazor.Documents.excel/excel.js"></script>
     <script src="BlazorDownloadFile.js"></script>
+	 <script src="_content/IgniteUI.Blazor/app.bundle.js"></script>
 
 </body>
 

--- a/samples/excel/excel-library/overview/App.razor
+++ b/samples/excel/excel-library/overview/App.razor
@@ -11,6 +11,9 @@
 @using Microsoft.JSInterop
 @using Microsoft.JSInterop.WebAssembly
 @using Infragistics.Documents.Excel
+@using System.Runtime.InteropServices.JavaScript
+
+@implements IDisposable
 
 <div class="container vertical">
 
@@ -228,11 +231,29 @@
         this.SaveFile(bytes, fileName, mime);
     }
 
-    private void SaveFile(byte[] bytes, string fileName, string mime)
+    JSObject module;
+    bool moduleDownloaded = false;
+    public async void SaveFile(byte[] bytes, string fileName, string mime)
     {
-        if (this.Runtime is WebAssemblyJSRuntime wasmRuntime)
-            wasmRuntime.InvokeUnmarshalled<string, string, byte[], bool>("BlazorDownloadFileFast", fileName, mime, bytes);
-        else if (this.Runtime is IJSInProcessRuntime inProc)
+        if (Runtime is WebAssemblyJSRuntime wasmRuntime)
+        {
+            if (!moduleDownloaded)
+            {
+                module = await JSHost.ImportAsync("BlazorFastDownload", "../BlazorFastDownloadFile.js");
+                moduleDownloaded = true;
+            }
+            BlazorFastDownload.DownloadFile(fileName, mime, bytes);
+        }
+        else if (Runtime is IJSInProcessRuntime inProc)
             inProc.InvokeVoid("BlazorDownloadFile", fileName, mime, bytes);
+
+
+    }
+    public void Dispose()
+    {
+        if (moduleDownloaded && module != null)
+        {
+            module.Dispose();
+        }
     }
 }

--- a/samples/excel/excel-library/overview/BlazorClientApp.csproj
+++ b/samples/excel/excel-library/overview/BlazorClientApp.csproj
@@ -5,6 +5,8 @@
     <RazorLangVersion>3.0</RazorLangVersion>
     <AssemblyName>Infragistics.Samples</AssemblyName>
     <RootNamespace>Infragistics.Samples</RootNamespace>
+		<!-- this is required for excel WASM samples for fast file download -->
+	 <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -12,12 +14,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="IgniteUI.Blazor" Version="24.2.40" />
-      <PackageReference Include="IgniteUI.Blazor.Documents.Excel" Version="24.2.40" />
+      <PackageReference Include="IgniteUI.Blazor" Version="24.2.42" />
+      <PackageReference Include="IgniteUI.Blazor.Documents.Excel" Version="24.2.42" />
       <PackageReference Include="Microsoft.AspNetCore.Components" Version="9.0.0" />
       <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
 
       <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0" />
+
+      <PackageReference Include="Microsoft.JSInterop.WebAssembly" Version="9.0.0" />
       <PackageReference Include="System.Net.Http.Json" Version="9.0.0" />
   </ItemGroup>
 

--- a/samples/excel/excel-library/overview/BlazorFastDownload.cs
+++ b/samples/excel/excel-library/overview/BlazorFastDownload.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.InteropServices.JavaScript;
+
+namespace Infragistics.Samples
+{
+    public partial class BlazorFastDownload
+    {
+        [JSImport("BlazorDownloadFileFast", "BlazorFastDownload")]
+        internal static partial void DownloadFile(string name, string contentType, byte[] content);
+
+    }
+}

--- a/samples/excel/excel-library/overview/wwwroot/BlazorDownloadFile.js
+++ b/samples/excel/excel-library/overview/wwwroot/BlazorDownloadFile.js
@@ -1,23 +1,6 @@
 ﻿// these methods are from:
 // https://www.meziantou.net/generating-and-downloading-a-file-in-a-blazor-webassembly-application.htm
-function BlazorDownloadFileFast(name, contentType, content) {
-    // Convert the parameters to actual JS types
-    var nameStr = BINDING.conv_string(name);
-    var contentTypeStr = BINDING.conv_string(contentType);
-    var contentArray = Blazor.platform.toUint8Array(content);
-    // Create the URL
-    var file = new File([contentArray], nameStr, { type: contentTypeStr });
-    var exportUrl = URL.createObjectURL(file);
-    // Create the <a> element and click on it
-    var a = document.createElement("a");
-    document.body.appendChild(a);
-    a.href = exportUrl;
-    a.download = nameStr;
-    a.target = "_self";
-    a.click();
-    // We don't need to keep the url, let's release the memory
-    URL.revokeObjectURL(exportUrl);
-}
+
 function BlazorDownloadFile(filename, contentType, content) {
     // Blazor marshall byte[] to a base64 string, so we first need to convert the string (content) to a Uint8Array to create the File
     var data = base64DecToArr(content);

--- a/samples/excel/excel-library/overview/wwwroot/BlazorFastDownloadFile.js
+++ b/samples/excel/excel-library/overview/wwwroot/BlazorFastDownloadFile.js
@@ -1,0 +1,20 @@
+﻿// these methods are from:
+// https://www.meziantou.net/generating-and-downloading-a-file-in-a-blazor-webassembly-application.htm
+export function BlazorDownloadFileFast(name, contentType, content) {
+    // Convert the parameters to actual JS types
+    var nameStr = name;
+    var contentTypeStr = contentType;
+    var contentArray = new Uint8Array(content);
+    // Create the URL
+    var file = new File([contentArray], nameStr, { type: contentTypeStr });
+    var exportUrl = URL.createObjectURL(file);
+    // Create the <a> element and click on it
+    var a = document.createElement("a");
+    document.body.appendChild(a);
+    a.href = exportUrl;
+    a.download = nameStr;
+    a.target = "_self";
+    a.click();
+    // We don't need to keep the url, let's release the memory
+    URL.revokeObjectURL(exportUrl);
+}

--- a/samples/excel/excel-library/overview/wwwroot/index.html
+++ b/samples/excel/excel-library/overview/wwwroot/index.html
@@ -25,6 +25,7 @@
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="_content/IgniteUI.Blazor.Documents.excel/excel.js"></script>
     <script src="BlazorDownloadFile.js"></script>
+    <script src="_content/IgniteUI.Blazor/app.bundle.js"></script>
 </body>
 
 </html>

--- a/samples/excel/excel-library/working-with-cells/App.razor
+++ b/samples/excel/excel-library/working-with-cells/App.razor
@@ -11,6 +11,9 @@
 @using Microsoft.JSInterop
 @using Microsoft.JSInterop.WebAssembly
 @using Infragistics.Documents.Excel
+@using System.Runtime.InteropServices.JavaScript
+
+@implements IDisposable
 
 <div class="container vertical">
 
@@ -298,11 +301,29 @@
         this.SaveFile(bytes, fileName, mime);
     }
 
-    private void SaveFile(byte[] bytes, string fileName, string mime)
+    JSObject module;
+    bool moduleDownloaded = false;
+    public async void SaveFile(byte[] bytes, string fileName, string mime)
     {
-        if (this.Runtime is WebAssemblyJSRuntime wasmRuntime)
-            wasmRuntime.InvokeUnmarshalled<string, string, byte[], bool>("BlazorDownloadFileFast", fileName, mime, bytes);
-        else if (this.Runtime is IJSInProcessRuntime inProc)
+        if (Runtime is WebAssemblyJSRuntime wasmRuntime)
+        {
+            if (!moduleDownloaded)
+            {
+                module = await JSHost.ImportAsync("BlazorFastDownload", "../BlazorFastDownloadFile.js");
+                moduleDownloaded = true;
+            }
+            BlazorFastDownload.DownloadFile(fileName, mime, bytes);
+        }
+        else if (Runtime is IJSInProcessRuntime inProc)
             inProc.InvokeVoid("BlazorDownloadFile", fileName, mime, bytes);
+
+
+    }
+    public void Dispose()
+    {
+        if (moduleDownloaded && module != null)
+        {
+            module.Dispose();
+        }
     }
 }

--- a/samples/excel/excel-library/working-with-cells/BlazorClientApp.csproj
+++ b/samples/excel/excel-library/working-with-cells/BlazorClientApp.csproj
@@ -5,6 +5,8 @@
     <RazorLangVersion>3.0</RazorLangVersion>
     <AssemblyName>Infragistics.Samples</AssemblyName>
     <RootNamespace>Infragistics.Samples</RootNamespace>
+		<!-- this is required for excel WASM samples for fast file download -->
+	 <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -19,6 +21,8 @@
       <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
 
       <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0" />
+
+      <PackageReference Include="Microsoft.JSInterop.WebAssembly" Version="9.0.0" />
       <PackageReference Include="System.Net.Http.Json" Version="9.0.0" />
   </ItemGroup>
 

--- a/samples/excel/excel-library/working-with-cells/BlazorFastDownload.cs
+++ b/samples/excel/excel-library/working-with-cells/BlazorFastDownload.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.InteropServices.JavaScript;
+
+namespace Infragistics.Samples
+{
+    public partial class BlazorFastDownload
+    {
+        [JSImport("BlazorDownloadFileFast", "BlazorFastDownload")]
+        internal static partial void DownloadFile(string name, string contentType, byte[] content);
+
+    }
+}

--- a/samples/excel/excel-library/working-with-cells/wwwroot/BlazorDownloadFile.js
+++ b/samples/excel/excel-library/working-with-cells/wwwroot/BlazorDownloadFile.js
@@ -1,23 +1,6 @@
 ﻿// these methods are from:
 // https://www.meziantou.net/generating-and-downloading-a-file-in-a-blazor-webassembly-application.htm
-function BlazorDownloadFileFast(name, contentType, content) {
-    // Convert the parameters to actual JS types
-    var nameStr = BINDING.conv_string(name);
-    var contentTypeStr = BINDING.conv_string(contentType);
-    var contentArray = Blazor.platform.toUint8Array(content);
-    // Create the URL
-    var file = new File([contentArray], nameStr, { type: contentTypeStr });
-    var exportUrl = URL.createObjectURL(file);
-    // Create the <a> element and click on it
-    var a = document.createElement("a");
-    document.body.appendChild(a);
-    a.href = exportUrl;
-    a.download = nameStr;
-    a.target = "_self";
-    a.click();
-    // We don't need to keep the url, let's release the memory
-    URL.revokeObjectURL(exportUrl);
-}
+
 function BlazorDownloadFile(filename, contentType, content) {
     // Blazor marshall byte[] to a base64 string, so we first need to convert the string (content) to a Uint8Array to create the File
     var data = base64DecToArr(content);

--- a/samples/excel/excel-library/working-with-cells/wwwroot/BlazorFastDownloadFile.js
+++ b/samples/excel/excel-library/working-with-cells/wwwroot/BlazorFastDownloadFile.js
@@ -1,0 +1,20 @@
+﻿// these methods are from:
+// https://www.meziantou.net/generating-and-downloading-a-file-in-a-blazor-webassembly-application.htm
+export function BlazorDownloadFileFast(name, contentType, content) {
+    // Convert the parameters to actual JS types
+    var nameStr = name;
+    var contentTypeStr = contentType;
+    var contentArray = new Uint8Array(content);
+    // Create the URL
+    var file = new File([contentArray], nameStr, { type: contentTypeStr });
+    var exportUrl = URL.createObjectURL(file);
+    // Create the <a> element and click on it
+    var a = document.createElement("a");
+    document.body.appendChild(a);
+    a.href = exportUrl;
+    a.download = nameStr;
+    a.target = "_self";
+    a.click();
+    // We don't need to keep the url, let's release the memory
+    URL.revokeObjectURL(exportUrl);
+}

--- a/samples/excel/excel-library/working-with-cells/wwwroot/index.html
+++ b/samples/excel/excel-library/working-with-cells/wwwroot/index.html
@@ -25,6 +25,7 @@
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="_content/IgniteUI.Blazor.Documents.excel/excel.js"></script>
     <script src="BlazorDownloadFile.js"></script>
+	 <script src="_content/IgniteUI.Blazor/app.bundle.js"></script>
 </body>
 
 </html>

--- a/samples/excel/excel-library/working-with-charts/App.razor
+++ b/samples/excel/excel-library/working-with-charts/App.razor
@@ -3,7 +3,9 @@
 @using Microsoft.JSInterop.WebAssembly
 @using Infragistics.Documents.Excel
 @using IgniteUI.Blazor.Controls
+@using System.Runtime.InteropServices.JavaScript
 
+@implements IDisposable
 
 <div class="container vertical">
     <div class="options vertical">
@@ -196,12 +198,30 @@
         this.SaveFile(bytes, "ExelWorkbook.xlsx", string.Empty);
     }
 
-    private void SaveFile(byte[] bytes, string fileName, string mime)
+    JSObject module;
+    bool moduleDownloaded = false;
+    public async void SaveFile(byte[] bytes, string fileName, string mime)
     {
-        if (this.Runtime is WebAssemblyJSRuntime wasmRuntime)
-            wasmRuntime.InvokeUnmarshalled<string, string, byte[], bool>("BlazorDownloadFileFast", fileName, mime, bytes);
-        else if (this.Runtime is IJSInProcessRuntime inProc)
+        if (Runtime is WebAssemblyJSRuntime wasmRuntime)
+        {
+            if (!moduleDownloaded)
+            {
+                module = await JSHost.ImportAsync("BlazorFastDownload", "../BlazorFastDownloadFile.js");
+                moduleDownloaded = true;
+            }
+            BlazorFastDownload.DownloadFile(fileName, mime, bytes);
+        }
+        else if (Runtime is IJSInProcessRuntime inProc)
             inProc.InvokeVoid("BlazorDownloadFile", fileName, mime, bytes);
+
+
+    }
+    public void Dispose()
+    {
+        if (moduleDownloaded && module != null)
+        {
+            module.Dispose();
+        }
     }
 
 

--- a/samples/excel/excel-library/working-with-charts/BlazorClientApp.csproj
+++ b/samples/excel/excel-library/working-with-charts/BlazorClientApp.csproj
@@ -5,6 +5,8 @@
     <RazorLangVersion>3.0</RazorLangVersion>
     <AssemblyName>Infragistics.Samples</AssemblyName>
     <RootNamespace>Infragistics.Samples</RootNamespace>
+	<!-- this is required for excel WASM samples for fast file download -->
+	 <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -18,6 +20,8 @@
       <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
 
       <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0" />
+
+      <PackageReference Include="Microsoft.JSInterop.WebAssembly" Version="9.0.0" />
       <PackageReference Include="System.Net.Http.Json" Version="9.0.0" />
   </ItemGroup>
 

--- a/samples/excel/excel-library/working-with-charts/BlazorFastDownload.cs
+++ b/samples/excel/excel-library/working-with-charts/BlazorFastDownload.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.InteropServices.JavaScript;
+
+namespace Infragistics.Samples
+{
+    public partial class BlazorFastDownload
+    {
+        [JSImport("BlazorDownloadFileFast", "BlazorFastDownload")]
+        internal static partial void DownloadFile(string name, string contentType, byte[] content);
+
+    }
+}

--- a/samples/excel/excel-library/working-with-charts/wwwroot/BlazorDownloadFile.js
+++ b/samples/excel/excel-library/working-with-charts/wwwroot/BlazorDownloadFile.js
@@ -1,23 +1,6 @@
 ﻿// these methods are from:
 // https://www.meziantou.net/generating-and-downloading-a-file-in-a-blazor-webassembly-application.htm
-function BlazorDownloadFileFast(name, contentType, content) {
-    // Convert the parameters to actual JS types
-    var nameStr = BINDING.conv_string(name);
-    var contentTypeStr = BINDING.conv_string(contentType);
-    var contentArray = Blazor.platform.toUint8Array(content);
-    // Create the URL
-    var file = new File([contentArray], nameStr, { type: contentTypeStr });
-    var exportUrl = URL.createObjectURL(file);
-    // Create the <a> element and click on it
-    var a = document.createElement("a");
-    document.body.appendChild(a);
-    a.href = exportUrl;
-    a.download = nameStr;
-    a.target = "_self";
-    a.click();
-    // We don't need to keep the url, let's release the memory
-    URL.revokeObjectURL(exportUrl);
-}
+
 function BlazorDownloadFile(filename, contentType, content) {
     // Blazor marshall byte[] to a base64 string, so we first need to convert the string (content) to a Uint8Array to create the File
     var data = base64DecToArr(content);

--- a/samples/excel/excel-library/working-with-charts/wwwroot/BlazorFastDownloadFile.js
+++ b/samples/excel/excel-library/working-with-charts/wwwroot/BlazorFastDownloadFile.js
@@ -1,0 +1,20 @@
+﻿// these methods are from:
+// https://www.meziantou.net/generating-and-downloading-a-file-in-a-blazor-webassembly-application.htm
+export function BlazorDownloadFileFast(name, contentType, content) {
+    // Convert the parameters to actual JS types
+    var nameStr = name;
+    var contentTypeStr = contentType;
+    var contentArray = new Uint8Array(content);
+    // Create the URL
+    var file = new File([contentArray], nameStr, { type: contentTypeStr });
+    var exportUrl = URL.createObjectURL(file);
+    // Create the <a> element and click on it
+    var a = document.createElement("a");
+    document.body.appendChild(a);
+    a.href = exportUrl;
+    a.download = nameStr;
+    a.target = "_self";
+    a.click();
+    // We don't need to keep the url, let's release the memory
+    URL.revokeObjectURL(exportUrl);
+}

--- a/samples/excel/excel-library/working-with-charts/wwwroot/index.html
+++ b/samples/excel/excel-library/working-with-charts/wwwroot/index.html
@@ -27,7 +27,7 @@
     <script src="_content/IgniteUI.Blazor.Documents.excel/excel.js"></script>
     <script src="BlazorDownloadFile.js"></script>
     <!-- importing blazor script for IG Blazor: -->
-    <script src="_content/IgniteUI.Blazor/app.bundle.js"></script>
+    <!--<script src="_content/IgniteUI.Blazor/app.bundle.js"></script>-->
 </body>
 
 </html>

--- a/samples/excel/excel-library/working-with-sparklines/App.razor
+++ b/samples/excel/excel-library/working-with-sparklines/App.razor
@@ -12,7 +12,9 @@
 @using Microsoft.JSInterop.WebAssembly
 @using Infragistics.Documents.Excel
 @using IgniteUI.Blazor.Controls
+@using System.Runtime.InteropServices.JavaScript
 
+@implements IDisposable
 
 <div class="container vertical">
 
@@ -287,12 +289,30 @@
 
     }
 
-    public void SaveFile(byte[] bytes, string fileName, string mime)
+    JSObject module;
+    bool moduleDownloaded = false;
+    public async void SaveFile(byte[] bytes, string fileName, string mime)
     {
         if (Runtime is WebAssemblyJSRuntime wasmRuntime)
-            wasmRuntime.InvokeUnmarshalled<string, string, byte[], bool>("BlazorDownloadFileFast", fileName, mime, bytes);
+        {
+            if (!moduleDownloaded)
+            {
+                module = await JSHost.ImportAsync("BlazorFastDownload", "../BlazorFastDownloadFile.js");
+                moduleDownloaded = true;
+            }
+            BlazorFastDownload.DownloadFile(fileName, mime, bytes);
+        }
         else if (Runtime is IJSInProcessRuntime inProc)
             inProc.InvokeVoid("BlazorDownloadFile", fileName, mime, bytes);
+
+
+    }
+    public void Dispose()
+    {
+        if (moduleDownloaded && module != null)
+        {
+            module.Dispose();
+        }
     }
 
     public double GetRandom(double min, double max)

--- a/samples/excel/excel-library/working-with-sparklines/BlazorClientApp.csproj
+++ b/samples/excel/excel-library/working-with-sparklines/BlazorClientApp.csproj
@@ -5,6 +5,8 @@
     <RazorLangVersion>3.0</RazorLangVersion>
     <AssemblyName>Infragistics.Samples</AssemblyName>
     <RootNamespace>Infragistics.Samples</RootNamespace>
+	<!-- this is required for excel WASM samples for fast file download -->
+	 <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -18,6 +20,8 @@
       <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
 
       <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0" />
+
+      <PackageReference Include="Microsoft.JSInterop.WebAssembly" Version="9.0.0" />
       <PackageReference Include="System.Net.Http.Json" Version="9.0.0" />
   </ItemGroup>
 

--- a/samples/excel/excel-library/working-with-sparklines/BlazorFastDownload.cs
+++ b/samples/excel/excel-library/working-with-sparklines/BlazorFastDownload.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.InteropServices.JavaScript;
+
+namespace Infragistics.Samples
+{
+    public partial class BlazorFastDownload
+    {
+        [JSImport("BlazorDownloadFileFast", "BlazorFastDownload")]
+        internal static partial void DownloadFile(string name, string contentType, byte[] content);
+
+    }
+}

--- a/samples/excel/excel-library/working-with-sparklines/wwwroot/BlazorDownloadFile.js
+++ b/samples/excel/excel-library/working-with-sparklines/wwwroot/BlazorDownloadFile.js
@@ -1,23 +1,6 @@
 ﻿// these methods are from:
 // https://www.meziantou.net/generating-and-downloading-a-file-in-a-blazor-webassembly-application.htm
-function BlazorDownloadFileFast(name, contentType, content) {
-    // Convert the parameters to actual JS types
-    var nameStr = BINDING.conv_string(name);
-    var contentTypeStr = BINDING.conv_string(contentType);
-    var contentArray = Blazor.platform.toUint8Array(content);
-    // Create the URL
-    var file = new File([contentArray], nameStr, { type: contentTypeStr });
-    var exportUrl = URL.createObjectURL(file);
-    // Create the <a> element and click on it
-    var a = document.createElement("a");
-    document.body.appendChild(a);
-    a.href = exportUrl;
-    a.download = nameStr;
-    a.target = "_self";
-    a.click();
-    // We don't need to keep the url, let's release the memory
-    URL.revokeObjectURL(exportUrl);
-}
+
 function BlazorDownloadFile(filename, contentType, content) {
     // Blazor marshall byte[] to a base64 string, so we first need to convert the string (content) to a Uint8Array to create the File
     var data = base64DecToArr(content);

--- a/samples/excel/excel-library/working-with-sparklines/wwwroot/BlazorFastDownloadFile.js
+++ b/samples/excel/excel-library/working-with-sparklines/wwwroot/BlazorFastDownloadFile.js
@@ -1,0 +1,20 @@
+﻿// these methods are from:
+// https://www.meziantou.net/generating-and-downloading-a-file-in-a-blazor-webassembly-application.htm
+export function BlazorDownloadFileFast(name, contentType, content) {
+    // Convert the parameters to actual JS types
+    var nameStr = name;
+    var contentTypeStr = contentType;
+    var contentArray = new Uint8Array(content);
+    // Create the URL
+    var file = new File([contentArray], nameStr, { type: contentTypeStr });
+    var exportUrl = URL.createObjectURL(file);
+    // Create the <a> element and click on it
+    var a = document.createElement("a");
+    document.body.appendChild(a);
+    a.href = exportUrl;
+    a.download = nameStr;
+    a.target = "_self";
+    a.click();
+    // We don't need to keep the url, let's release the memory
+    URL.revokeObjectURL(exportUrl);
+}


### PR DESCRIPTION
since InvokeUnmarshalled is deprecated in .Net9 switch from using this to using JSImport to download excel files in WASM 