### PR TITLE
Add PlotAreaMargin to stacked Chart samples to ensure end markers are fully visible

### DIFF
--- a/samples/charts/data-chart/stacked-100-area-chart/App.razor
+++ b/samples/charts/data-chart/stacked-100-area-chart/App.razor
@@ -17,7 +17,11 @@
         Name="chart"
         @ref="chart"
         IsHorizontalZoomEnabled="false"
-        IsVerticalZoomEnabled="false">
+        IsVerticalZoomEnabled="false"
+        PlotAreaMarginTop="12"
+        PlotAreaMarginBottom="12"
+        PlotAreaMarginLeft="12"
+        PlotAreaMarginRight="12">
             <IgbCategoryXAxis
             Name="xAxis"
             @ref="xAxis"

--- a/samples/charts/data-chart/stacked-100-line-chart/App.razor
+++ b/samples/charts/data-chart/stacked-100-line-chart/App.razor
@@ -17,7 +17,11 @@
         Name="chart"
         @ref="chart"
         IsHorizontalZoomEnabled="false"
-        IsVerticalZoomEnabled="false">
+        IsVerticalZoomEnabled="false"
+        PlotAreaMarginTop="12"
+        PlotAreaMarginBottom="12"
+        PlotAreaMarginLeft="12"
+        PlotAreaMarginRight="12">
             <IgbCategoryXAxis
             Name="xAxis"
             @ref="xAxis"

--- a/samples/charts/data-chart/stacked-100-spline-area-chart/App.razor
+++ b/samples/charts/data-chart/stacked-100-spline-area-chart/App.razor
@@ -17,7 +17,11 @@
         Name="chart"
         @ref="chart"
         IsHorizontalZoomEnabled="false"
-        IsVerticalZoomEnabled="false">
+        IsVerticalZoomEnabled="false"
+        PlotAreaMarginTop="12"
+        PlotAreaMarginBottom="12"
+        PlotAreaMarginLeft="12"
+        PlotAreaMarginRight="12">
             <IgbCategoryXAxis
             Name="xAxis"
             @ref="xAxis"

--- a/samples/charts/data-chart/stacked-100-spline-chart/App.razor
+++ b/samples/charts/data-chart/stacked-100-spline-chart/App.razor
@@ -17,7 +17,11 @@
         Name="chart"
         @ref="chart"
         IsHorizontalZoomEnabled="false"
-        IsVerticalZoomEnabled="false">
+        IsVerticalZoomEnabled="false"
+        PlotAreaMarginTop="12"
+        PlotAreaMarginBottom="12"
+        PlotAreaMarginLeft="12"
+        PlotAreaMarginRight="12">
             <IgbCategoryXAxis
             Name="xAxis"
             @ref="xAxis"

--- a/samples/charts/data-chart/stacked-area-chart/App.razor
+++ b/samples/charts/data-chart/stacked-area-chart/App.razor
@@ -17,7 +17,11 @@
         Name="chart"
         @ref="chart"
         IsHorizontalZoomEnabled="false"
-        IsVerticalZoomEnabled="false">
+        IsVerticalZoomEnabled="false"
+        PlotAreaMarginTop="12"
+        PlotAreaMarginBottom="12"
+        PlotAreaMarginLeft="12"
+        PlotAreaMarginRight="12">
             <IgbCategoryXAxis
             Name="xAxis"
             @ref="xAxis"

--- a/samples/charts/data-chart/stacked-line-chart/App.razor
+++ b/samples/charts/data-chart/stacked-line-chart/App.razor
@@ -17,7 +17,11 @@
         Name="chart"
         @ref="chart"
         IsHorizontalZoomEnabled="false"
-        IsVerticalZoomEnabled="false">
+        IsVerticalZoomEnabled="false"
+        PlotAreaMarginTop="12"
+        PlotAreaMarginBottom="12"
+        PlotAreaMarginLeft="12"
+        PlotAreaMarginRight="12">
             <IgbCategoryXAxis
             Name="xAxis"
             @ref="xAxis"

--- a/samples/charts/data-chart/stacked-spline-area-chart/App.razor
+++ b/samples/charts/data-chart/stacked-spline-area-chart/App.razor
@@ -17,7 +17,11 @@
         Name="chart"
         @ref="chart"
         IsHorizontalZoomEnabled="false"
-        IsVerticalZoomEnabled="false">
+        IsVerticalZoomEnabled="false"
+        PlotAreaMarginTop="12"
+        PlotAreaMarginBottom="12"
+        PlotAreaMarginLeft="12"
+        PlotAreaMarginRight="12">
             <IgbCategoryXAxis
             Name="xAxis"
             @ref="xAxis"

--- a/samples/charts/data-chart/stacked-spline-chart/App.razor
+++ b/samples/charts/data-chart/stacked-spline-chart/App.razor
@@ -17,7 +17,11 @@
         Name="chart"
         @ref="chart"
         IsHorizontalZoomEnabled="false"
-        IsVerticalZoomEnabled="false">
+        IsVerticalZoomEnabled="false"
+        PlotAreaMarginTop="12"
+        PlotAreaMarginBottom="12"
+        PlotAreaMarginLeft="12"
+        PlotAreaMarginRight="12">
             <IgbCategoryXAxis
             Name="xAxis"
             @ref="xAxis"


### PR DESCRIPTION
Resolves IgniteUI/igniteui-xplat-examples#973 