### PR TITLE
fix(badge): escape @ to @@ when inlining sample CSS into Razor App files

### DIFF
--- a/browser/IgBlazorSamples.Gulp/tasks/Transformer.ts
+++ b/browser/IgBlazorSamples.Gulp/tasks/Transformer.ts
@@ -1034,8 +1034,10 @@ class Transformer {
                     if (cssContent !== defaultCSS) {
                         // console.log("GULP injecting \n" + cssContent)
                         console.log("- injecting CSS from " + css.Path)
+                        // escape @ as @@ since CSS is inlined into a .razor file where @ is Blazor syntax
+                        let inlineCss = Strings.replaceAll(cssContent, '@', '@@');
                         stylingLines.push('<style>');
-                        stylingLines.push(cssContent);
+                        stylingLines.push(inlineCss);
                         stylingLines.push('</style>');
                     }
                 }

--- a/samples/inputs/badge/outlined/wwwroot/index.css
+++ b/samples/inputs/badge/outlined/wwwroot/index.css
@@ -16,7 +16,7 @@ https://dl.infragistics.com/x/css//samples/
 }
 
 igc-avatar {
-  @container style(--ig-theme: indigo) {
+  @@container style(--ig-theme: indigo) {
     --ig-size: var(--ig-size-large);
   }
 

--- a/samples/inputs/badge/outlined/wwwroot/index.css
+++ b/samples/inputs/badge/outlined/wwwroot/index.css
@@ -16,7 +16,7 @@ https://dl.infragistics.com/x/css//samples/
 }
 
 igc-avatar {
-  @@container style(--ig-theme: indigo) {
+  @container style(--ig-theme: indigo) {
     --ig-size: var(--ig-size-large);
   }
 


### PR DESCRIPTION
The issue here is that when building the samples browser as a solution, it copies the css files as inline files and uses a single App.razor file per sample. And the `@container` rule (along with any `@` in CSS) messes up Blazor, since `@` is used for Blazor syntax in Razor files.

<img src="https://github.com/user-attachments/assets/dd2c6fc7-4fa0-4475-8f4a-1e7123332eda">

Rather than altering the source CSS, the escaping is now done at the inlining step: `Transformer.ts` replaces `@` with `@@` when injecting CSS into the generated App.razor `<style>` block. This keeps the standalone sample `wwwroot/index.css` valid while the inlined Razor builds correctly.

<img src="https://github.com/user-attachments/assets/05a728bd-137a-425c-82bc-1a29eb5ba598">