### PR TITLE
fix(grid): Add modules missing from samples causing issues.

### DIFF
--- a/samples/grids/grid/binding-nested-data-1/Program.cs
+++ b/samples/grids/grid/binding-nested-data-1/Program.cs
@@ -21,7 +21,8 @@ namespace Infragistics.Samples
             // registering Ignite UI modules
             builder.Services.AddIgniteUIBlazor(
                 typeof(IgbGridModule),
-                typeof(IgbInputModule)
+                typeof(IgbInputModule),
+                typeof(IgbExpansionPanelModule)
             );
             await builder.Build().RunAsync();
         }

--- a/samples/grids/grid/cascading-combo/Program.cs
+++ b/samples/grids/grid/cascading-combo/Program.cs
@@ -21,7 +21,8 @@ namespace Infragistics.Samples
             // registering Ignite UI modules
             builder.Services.AddIgniteUIBlazor(
                 typeof(IgbGridModule),
-                typeof(IgbComboModule)
+                typeof(IgbComboModule),
+                typeof(IgbLinearProgressModule)
             );
             await builder.Build().RunAsync();
         }

--- a/samples/grids/grid/cell-merge/Program.cs
+++ b/samples/grids/grid/cell-merge/Program.cs
@@ -20,9 +20,7 @@ namespace Infragistics.Samples
             builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
             // registering Ignite UI modules
             builder.Services.AddIgniteUIBlazor(
-                typeof(IgbGridModule)
-            );
-            builder.Services.AddIgniteUIBlazor(
+                typeof(IgbGridModule),
                 typeof(IgbSelectModule)
             );
             await builder.Build().RunAsync();

--- a/samples/grids/grid/change-icons-custom/Program.cs
+++ b/samples/grids/grid/change-icons-custom/Program.cs
@@ -22,7 +22,8 @@ namespace Infragistics.Samples
             builder.Services.AddIgniteUIBlazor(
                 typeof(IgbInputModule),
                 typeof(IgbPropertyEditorPanelModule),
-                typeof(IgbGridModule)
+                typeof(IgbGridModule),
+                typeof(IgbIconModule)
             );
             await builder.Build().RunAsync();
         }

--- a/samples/grids/grid/data-validator-service/Program.cs
+++ b/samples/grids/grid/data-validator-service/Program.cs
@@ -22,7 +22,8 @@ namespace Infragistics.Samples
             builder.Services.AddIgniteUIBlazor(
                 typeof(IgbInputModule),
                 typeof(IgbPropertyEditorPanelModule),
-                typeof(IgbGridModule)
+                typeof(IgbGridModule),
+                typeof(IgbAvatarModule)
             );
             await builder.Build().RunAsync();
         }

--- a/samples/grids/grid/groupby-expressions/Program.cs
+++ b/samples/grids/grid/groupby-expressions/Program.cs
@@ -20,7 +20,8 @@ namespace Infragistics.Samples
             builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
             // registering Ignite UI modules
             builder.Services.AddIgniteUIBlazor(
-                typeof(IgbGridModule)
+                typeof(IgbGridModule),
+                typeof(IgbBadgeModule)
             );
             await builder.Build().RunAsync();
         }

--- a/samples/grids/grid/groupby-paging/Program.cs
+++ b/samples/grids/grid/groupby-paging/Program.cs
@@ -20,7 +20,8 @@ namespace Infragistics.Samples
             builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
             // registering Ignite UI modules
             builder.Services.AddIgniteUIBlazor(
-                typeof(IgbGridModule)
+                typeof(IgbGridModule),
+                typeof(IgbBadgeModule)
             );
             await builder.Build().RunAsync();
         }


### PR DESCRIPTION
Since 26.1.72, the samples in this PR have basic components used in the grid template, which if not registered do not work.